### PR TITLE
Update 21.context-wrapper.md

### DIFF
--- a/patterns/21.context-wrapper.md
+++ b/patterns/21.context-wrapper.md
@@ -104,7 +104,7 @@ export function register(key, dependency) {
 }
 
 export function fetch(key) {
-  if (dependencies[key]) return dependencies[key];
+  if (key in dependencies) return dependencies[key];
   throw new Error(`"${ key } is not registered as dependency.`);
 }
 


### PR DESCRIPTION
if deps[key] is a falsy value this will error even though the property exists
use in operator to avoid that